### PR TITLE
Update title from 'Standards' to 'Matlab Code Standards'

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -1,2 +1,2 @@
-* [Standards](matlab_standards.md)
+* [Matlab Code Standards](matlab_standards.md)
 

--- a/matlab_standards.md
+++ b/matlab_standards.md
@@ -1,4 +1,4 @@
-# Standards
+# Matlab Code Standards
 
 # Naming Conventions
 


### PR DESCRIPTION
Felt the latter was a bit more descriptive.

I probably missed an edit in a file somewhere :-).